### PR TITLE
Repository resolution

### DIFF
--- a/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/CompositeBuildExtensions.kt
+++ b/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/CompositeBuildExtensions.kt
@@ -1,21 +1,20 @@
 package io.github.woody230.gradle.convention
 
-import org.gradle.api.Project
 import org.gradle.api.invocation.Gradle
 
 /**
- * Creates a sequence of the builds starting from the current build that iterates toward the root of the composite.
+ * Creates a sequence of the Gradle instance starting from the given instance that iterates toward the root of the composite.
  */
-fun Project.compositeBuildSequence(): Sequence<Gradle> = generateSequence(project.gradle) { build -> build.parent }
+fun Gradle.compositeSequence(): Sequence<Gradle> = generateSequence(this) { build -> build.parent }
 
 /**
- * The root build of the composite.
+ * The root Gradle instance of the composite.
  */
-val Project.compositeRootBuild: Gradle
-    get() = compositeBuildSequence().last()
+val Gradle.compositeRoot: Gradle
+    get() = compositeSequence().last()
 
 /**
- * The root project of the composite.
+ * Whether this Gradle instance is the root of the composite.
  */
-val Project.compositeRootProject: Project
-    get() = compositeRootBuild.rootProject
+val Gradle.isCompositeRoot: Boolean
+    get() = parent == null

--- a/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/CompositePropertyExtensions.kt
+++ b/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/CompositePropertyExtensions.kt
@@ -1,0 +1,29 @@
+package io.github.woody230.gradle.convention
+
+import org.gradle.api.Project
+import java.io.File
+import java.util.*
+
+/**
+ * The composite.properties from the root directory.
+ */
+val Project.compositeProperties: Properties
+    get() = compositePropertiesFileOrNull.load()
+
+/**
+ * The composite.properties file from the root directory.
+ */
+val Project.compositePropertiesFileOrNull: File?
+    get() = propertiesFileOrNull("composite.properties")
+
+/**
+ * The composite.properties from the root directory of this project or from a parent build.
+ */
+val Project.compositeCompositeProperties: Properties
+    get() = compositeCompositePropertiesFileOrNull.load()
+
+/**
+ * The composite.properties file from the root directory of this project or from a parent build.
+ */
+val Project.compositeCompositePropertiesFileOrNull: File?
+    get() = gradle.compositeSequence().firstNotNullOfOrNull { gradle -> gradle.rootProject.compositePropertiesFileOrNull }

--- a/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/LocalPropertyExtensions.kt
+++ b/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/LocalPropertyExtensions.kt
@@ -2,27 +2,28 @@ package io.github.woody230.gradle.convention
 
 import org.gradle.api.Project
 import java.io.File
-import java.io.FileInputStream
-import java.io.InputStreamReader
 import java.util.*
 
+/**
+ * The local.properties from the root directory.
+ */
 val Project.localProperties: Properties
-    get() {
-        val properties = Properties()
-        localPropertiesFile?.let { localProperties ->
-            InputStreamReader(FileInputStream(localProperties), Charsets.UTF_8).use { reader ->
-                properties.load(reader)
-            }
-        }
+    get() = localPropertiesFileOrNull.load()
 
-        return properties
-    }
+/**
+ * The local.properties file from the root directory.
+ */
+val Project.localPropertiesFileOrNull: File?
+    get() = propertiesFileOrNull("local.properties")
 
-private val Project.localPropertiesFile: File?
-    get() = compositeBuildSequence().firstNotNullOfOrNull { build ->
-        val file = build.rootProject.rootDir.resolve("local.properties")
-        when {
-            file.isFile -> file
-            else -> null
-        }
-    }
+/**
+ * The local.properties from the root directory of this project or from a parent build.
+ */
+val Project.compositeLocalProperties: Properties
+    get() = compositeLocalPropertiesFileOrNull.load()
+
+/**
+ * The local.properties file from the root directory of this project or from a parent build.
+ */
+val Project.compositeLocalPropertiesFileOrNull: File?
+    get() = gradle.compositeSequence().firstNotNullOfOrNull { gradle -> gradle.rootProject.localPropertiesFileOrNull }

--- a/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/PropertyExtensions.kt
+++ b/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/PropertyExtensions.kt
@@ -1,6 +1,9 @@
 package io.github.woody230.gradle.convention
 
 import org.gradle.api.Project
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStreamReader
 import java.util.*
 
 fun Properties.containsKeys(vararg keys: String) = keys.all(::containsKey)
@@ -9,10 +12,53 @@ fun Project.hasProperties(vararg keys: String) = keys.all(::hasProperty)
 
 fun Project.getProperty(key: String): String = properties[key]?.toString() ?: throw Error("Gradle property $key does not exist.")
 
+fun Project.addOrSkipProperty(key: String, value: String) {
+    if (hasProperty(key)) {
+        return
+    }
+
+    addOrReplaceProperty(key, value)
+}
+
+fun Project.addOrSkipProperties(properties: Properties) {
+    properties.forEach { pair ->
+        val key = pair.key.toString()
+        val value = pair.value.toString()
+        addOrSkipProperty(key, value)
+    }
+}
+
 fun Project.addOrReplaceProperty(key: String, value: String) {
     if (hasProperty(key)) {
         setProperty(key, value)
     } else {
         extensions.extraProperties.set(key, value)
     }
+}
+
+fun Project.addOrReplaceProperties(properties: Properties) {
+    properties.forEach { pair ->
+        val key = pair.key.toString()
+        val value = pair.value.toString()
+        addOrReplaceProperty(key, value)
+    }
+}
+
+internal fun Project.propertiesFileOrNull(name: String): File? {
+    val file = rootDir.resolve(name)
+    return when {
+        file.isFile -> file
+        else -> null
+    }
+}
+
+internal fun File?.load(): Properties {
+    val properties = Properties()
+    if (this != null) {
+        InputStreamReader(FileInputStream(this), Charsets.UTF_8).use { reader ->
+            properties.load(reader)
+        }
+    }
+
+    return properties
 }

--- a/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/publish.gradle.kts
+++ b/convention-plugins/src/main/kotlin/io/github/woody230/gradle/convention/publish.gradle.kts
@@ -56,8 +56,8 @@ mavenPublishing {
     }
 }
 
-fun Project.setupGradleProperties() = with(properties) {
-    val localProperties = localProperties
+fun Project.setupGradleProperties() {
+    val localProperties = compositeLocalProperties
 
     if (localProperties.containsKeys(LocalProperty.SONATYPE_USERNAME, LocalProperty.SONATYPE_PASSWORD)) {
         addOrReplaceProperty(GradleProperty.MAVEN_CENTRAL_USERNAME, localProperties.getProperty(LocalProperty.SONATYPE_USERNAME))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ moko-resources = "0.22.0"
 multiplatform-compose = "1.4.1" # Must also update androidx-compose version with the compiler version.
 toolchain = "0.4.0"
 vanniktech-publish = "0.25.2"
-woody230-gradle = "1.2.0"
+woody230-gradle = "1.2.1"
 
 [libraries]
 aboutlibraries-core = { group = "com.mikepenz", name = "aboutlibraries-core", version.ref = "aboutlibraries" }

--- a/internal-publish-plugins/maven-publish-plugin/src/main/kotlin/com/bselzer/gradle/internal/maven/publish/plugin/MavenPublishPlugin.kt
+++ b/internal-publish-plugins/maven-publish-plugin/src/main/kotlin/com/bselzer/gradle/internal/maven/publish/plugin/MavenPublishPlugin.kt
@@ -110,7 +110,7 @@ abstract class MavenPublishPlugin : Plugin<Project> {
         configureScm(repo)
     }
 
-    private fun Project.setupGradleProperties() = with(properties) {
+    private fun Project.setupGradleProperties() {
         val localProperties = compositeLocalProperties
 
         if (localProperties.containsKeys(LocalProperty.SONATYPE_USERNAME, LocalProperty.SONATYPE_PASSWORD)) {

--- a/internal-settings-plugins/bundled-plugin/src/main/kotlin/com/bselzer/gradle/internal/bundled/plugin/BundledPlugin.kt
+++ b/internal-settings-plugins/bundled-plugin/src/main/kotlin/com/bselzer/gradle/internal/bundled/plugin/BundledPlugin.kt
@@ -30,9 +30,9 @@ class BundledPlugin : Plugin<Settings> {
     }
 
     private fun RepositoryHandler.addRepositories() {
-        gradlePluginPortal()
         google()
         mavenCentral()
+        gradlePluginPortal()
         mavenLocal()
     }
 


### PR DESCRIPTION
Move gradlePluginPortal to the bottom of the repository list.

Convention plugins: use up to date extensions from function module.